### PR TITLE
Version 1.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [v1.0.2] - Maestro API v1.0.0-1.0.5 - 2024-11-15
+### Changed
+- Resolved an issue that prevented the use of `RequestJWTApplicationToken` with a production account URL.
+- Updated C# SDK dependencies.
+    - BouncyCastle.Cryptography: Version bumped from 2.3.1 to 2.4.0.
+    - Microsoft.IdentityModelJsonWebTokens: Version bumped from 7.5.2 to 8.2.0.
+- Updated the SDK release version.
+
 ## [v1.0.1] - Maestro API v1.0.0-1.0.5 - 2024-11-07
 ### Changed
 - Fixed Deadlock issue with UI Apps (E.g. WinForms).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This client SDK is provided as open source, which enables you to customize its f
 <a id="versionInformation"></a>
 ### Version Information
 - **API version**: 1.0.0
-- **Latest SDK version (Including prerelease)**: 1.0.1
+- **Latest SDK version (Including prerelease)**: 1.0.2
 
 <a id="requirements"></a>
 ### Requirements

--- a/sdk/DocuSign.Maestro.sln
+++ b/sdk/DocuSign.Maestro.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.Maestro", "src\DocuSign.Maestro\DocuSign.Maestro.csproj", "{AF0E1F27-2C62-4D82-BD11-1F15259972FD}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.Maestro", "src\DocuSign.Maestro\DocuSign.Maestro.csproj", "{879CADF6-42C3-406F-AD70-C05BFA5F75AB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -10,10 +10,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{AF0E1F27-2C62-4D82-BD11-1F15259972FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AF0E1F27-2C62-4D82-BD11-1F15259972FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AF0E1F27-2C62-4D82-BD11-1F15259972FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AF0E1F27-2C62-4D82-BD11-1F15259972FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{879CADF6-42C3-406F-AD70-C05BFA5F75AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{879CADF6-42C3-406F-AD70-C05BFA5F75AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{879CADF6-42C3-406F-AD70-C05BFA5F75AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{879CADF6-42C3-406F-AD70-C05BFA5F75AB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/src/DocuSign.Maestro/Client/Configuration.cs
+++ b/sdk/src/DocuSign.Maestro/Client/Configuration.cs
@@ -26,7 +26,7 @@ namespace DocuSign.Maestro.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "1.0.1";
+        public const string Version = "1.0.2";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format

--- a/sdk/src/DocuSign.Maestro/Client/DocuSignClient.cs
+++ b/sdk/src/DocuSign.Maestro/Client/DocuSignClient.cs
@@ -220,9 +220,9 @@ namespace DocuSign.Maestro.Client
         /// <value>An instance of the RestClient</value>
         public IHttpClient RestClient { get; set; }
 
-        public DocuSignRequest PrepareOAuthRequest(string oAuthBasePath, string path, HttpMethod method, List<KeyValuePair<string, string>> headerParams = null, List<KeyValuePair<string, string>> formParams = null)
+        public DocuSignRequest PrepareOAuthRequest(string oAuthBasePathParam, string path, HttpMethod method, List<KeyValuePair<string, string>> headerParams = null, List<KeyValuePair<string, string>> formParams = null)
         {
-            string url = $"https://{oAuthBasePath}/{path}";
+            string url = $"https://{oAuthBasePathParam}/{path}";
             
             if (!headerParams.Any(kvp => kvp.Key?.Equals("Content-Type") ?? false)) { headerParams.Add(new KeyValuePair<string, string>("Content-Type", "application/x-www-form-urlencoded")); }
             if (!headerParams.Any(kvp => kvp.Key?.Equals("Cache-Control") ?? false)) { headerParams.Add(new KeyValuePair<string, string>("Cache-Control", "no-store")); }
@@ -914,7 +914,7 @@ namespace DocuSign.Maestro.Client
             if (localVarHeaderParams.ContainsKey("Authorization")) { localVarHeaderParams.Remove("Authorization"); }
             localVarHeaderParams.Add("Authorization", "Bearer " + accessToken);
 
-            DocuSignRequest request = PrepareOAuthRequest(oAuthBasePath, $"oauth/userinfo", HttpMethod.Get, localVarHeaderParams.ToList(), localVarFormParams.ToList());
+            DocuSignRequest request = PrepareOAuthRequest(this.oAuthBasePath, $"oauth/userinfo", HttpMethod.Get, localVarHeaderParams.ToList(), localVarFormParams.ToList());
             DocuSignResponse response = await RestClient.SendRequestAsync(request, cancellationToken);
 
             if (response.StatusCode >= HttpStatusCode.OK && response.StatusCode < HttpStatusCode.BadRequest)
@@ -964,7 +964,7 @@ namespace DocuSign.Maestro.Client
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="userId">Docusign user Id to be impersonated(This is a UUID)</param>
-        /// <param name="oauthBasePath"> Docusign OAuth base path
+        /// <param name="oAuthBasePathParam"> Docusign OAuth base path
         /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
@@ -974,12 +974,12 @@ namespace DocuSign.Maestro.Client
         /// <see cref="OAuth.Scope_SIGNATURE"/> <see cref="OAuth.Scope_IMPERSONATION"/> <see cref="OAuth.Scope_EXTENDED"/>
         /// </param>
         /// <returns>The JWT user token</returns>
-        public OAuth.OAuthToken RequestJWTUserToken(string clientId, string userId, string oauthBasePath, Stream privateKeyStream, int expiresInHours, List<string> scopes = null)
+        public OAuth.OAuthToken RequestJWTUserToken(string clientId, string userId, string oAuthBasePathParam, Stream privateKeyStream, int expiresInHours, List<string> scopes = null)
         {
             using (var cts = new CancellationTokenSource())
             {              
                 return TryCatchWrapper(() => {
-                    var task = Task.Run(async () => await RequestJWTUserTokenAsync(clientId, userId, oauthBasePath, privateKeyStream, expiresInHours, scopes, cts.Token));
+                    var task = Task.Run(async () => await RequestJWTUserTokenAsync(clientId, userId, oAuthBasePathParam, privateKeyStream, expiresInHours, scopes, cts.Token));
                     task.Wait();
                     return task.Result;
                 });
@@ -992,7 +992,7 @@ namespace DocuSign.Maestro.Client
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="userId">Docusign user Id to be impersonated(This is a UUID)</param>
-        /// <param name="oauthBasePath"> Docusign OAuth base path
+        /// <param name="oAuthBasePathParam"> Docusign OAuth base path
         /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
@@ -1003,12 +1003,12 @@ namespace DocuSign.Maestro.Client
         /// <see cref="OAuth.Scope_SIGNATURE"/> <see cref="OAuth.Scope_IMPERSONATION"/> <see cref="OAuth.Scope_EXTENDED"/>
         /// </param>
         /// <returns>The JWT user token</returns>
-        public async Task<OAuth.OAuthToken> RequestJWTUserTokenAsync(string clientId, string userId, string oauthBasePath, Stream privateKeyStream, int expiresInHours, List<string> scopes = null, CancellationToken cancellationToken = default)
+        public async Task<OAuth.OAuthToken> RequestJWTUserTokenAsync(string clientId, string userId, string oAuthBasePathParam, Stream privateKeyStream, int expiresInHours, List<string> scopes = null, CancellationToken cancellationToken = default)
         {
             if (privateKeyStream != null && privateKeyStream.CanRead && privateKeyStream.Length > 0)
             {
                 byte[] privateKeyBytes = ReadAsBytes(privateKeyStream);
-                return await this.RequestJWTUserTokenAsync(clientId, userId, oauthBasePath, privateKeyBytes, expiresInHours, scopes, cancellationToken);
+                return await this.RequestJWTUserTokenAsync(clientId, userId, oAuthBasePathParam, privateKeyBytes, expiresInHours, scopes, cancellationToken);
             }
             else
             {
@@ -1022,7 +1022,7 @@ namespace DocuSign.Maestro.Client
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="userId">Docusign user Id to be impersonated(This is a UUID)</param>
-        /// <param name="oauthBasePath"> Docusign OAuth base path
+        /// <param name="oAuthBasePathParam"> Docusign OAuth base path
         /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
@@ -1032,13 +1032,13 @@ namespace DocuSign.Maestro.Client
         /// <see cref="OAuth.Scope_SIGNATURE"/> <see cref="OAuth.Scope_IMPERSONATION"/> <see cref="OAuth.Scope_EXTENDED"/>
         /// </param>
         /// <returns>The JWT user token</returns>
-        public OAuth.OAuthToken RequestJWTUserToken(string clientId, string userId, string oauthBasePath, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null)
+        public OAuth.OAuthToken RequestJWTUserToken(string clientId, string userId, string oAuthBasePathParam, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null)
         {
 
             using (var cts = new CancellationTokenSource())
             {              
                 return TryCatchWrapper(() => {
-                    var task = Task.Run(async () => await RequestJWTUserTokenAsync(clientId, userId, oauthBasePath, privateKeyBytes, expiresInHours, scopes, cts.Token));
+                    var task = Task.Run(async () => await RequestJWTUserTokenAsync(clientId, userId, oAuthBasePathParam, privateKeyBytes, expiresInHours, scopes, cts.Token));
                     task.Wait();
                     return task.Result;
                 });
@@ -1051,7 +1051,7 @@ namespace DocuSign.Maestro.Client
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="userId">Docusign user Id to be impersonated(This is a UUID)</param>
-        /// <param name="oauthBasePath"> Docusign OAuth base path
+        /// <param name="oAuthBasePathParam"> Docusign OAuth base path
         /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
@@ -1062,7 +1062,7 @@ namespace DocuSign.Maestro.Client
         /// <see cref="OAuth.Scope_SIGNATURE"/> <see cref="OAuth.Scope_IMPERSONATION"/> <see cref="OAuth.Scope_EXTENDED"/>
         /// </param>
         /// <returns>The JWT user token</returns>
-        public async Task<OAuth.OAuthToken> RequestJWTUserTokenAsync(string clientId, string userId, string oauthBasePath, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null, CancellationToken cancellationToken = default)
+        public async Task<OAuth.OAuthToken> RequestJWTUserTokenAsync(string clientId, string userId, string oAuthBasePathParam, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null, CancellationToken cancellationToken = default)
         {
             string privateKey = Encoding.UTF8.GetString(privateKeyBytes);
 
@@ -1081,7 +1081,7 @@ namespace DocuSign.Maestro.Client
 
             descriptor.Subject = new ClaimsIdentity();
             descriptor.Subject.AddClaim(new Claim("scope", String.Join(" ", scopes)));
-            descriptor.Subject.AddClaim(new Claim("aud", oauthBasePath));
+            descriptor.Subject.AddClaim(new Claim("aud", oAuthBasePathParam));
             descriptor.Subject.AddClaim(new Claim("iss", clientId));
 
             if (!string.IsNullOrEmpty(userId))
@@ -1112,7 +1112,7 @@ namespace DocuSign.Maestro.Client
                 { "assertion", jwtToken }
             };
 
-            DocuSignRequest request = PrepareOAuthRequest(oauthBasePath, $"oauth/token", HttpMethod.Post, Configuration.DefaultHeader?.ToList(), localVarFormParams.ToList());
+            DocuSignRequest request = PrepareOAuthRequest(oAuthBasePathParam, $"oauth/token", HttpMethod.Post, Configuration.DefaultHeader?.ToList(), localVarFormParams.ToList());
             DocuSignResponse response = await RestClient.SendRequestAsync(request, cancellationToken);
 
             if (response.StatusCode >= HttpStatusCode.OK && response.StatusCode < HttpStatusCode.BadRequest)
@@ -1132,7 +1132,7 @@ namespace DocuSign.Maestro.Client
         /// *RESERVED FOR PARTNERS* RequestJWTApplicationToken
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
-        /// <param name="oauthBasePath"> Docusign OAuth base path
+        /// <param name="oAuthBasePathParam"> Docusign OAuth base path
         /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
@@ -1142,12 +1142,12 @@ namespace DocuSign.Maestro.Client
         /// <see cref="OAuth.Scope_SIGNATURE"/> <see cref="OAuth.Scope_IMPERSONATION"/> <see cref="OAuth.Scope_EXTENDED"/>
         /// </param>
         /// <returns>The JWT application token</returns>
-        public OAuth.OAuthToken RequestJWTApplicationToken(string clientId, string oauthBasePath, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null)
+        public OAuth.OAuthToken RequestJWTApplicationToken(string clientId, string oAuthBasePathParam, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null)
         {
             using (var cts = new CancellationTokenSource())
             {              
                 return TryCatchWrapper(() => {
-                    var task = Task.Run(async () => await RequestJWTApplicationTokenAsync(clientId, oAuthBasePath, privateKeyBytes, expiresInHours, scopes, cts.Token));
+                    var task = Task.Run(async () => await RequestJWTApplicationTokenAsync(clientId, oAuthBasePathParam, privateKeyBytes, expiresInHours, scopes, cts.Token));
                     task.Wait();
                     return task.Result;
                 });
@@ -1158,7 +1158,7 @@ namespace DocuSign.Maestro.Client
         /// *RESERVED FOR PARTNERS* RequestJWTApplicationTokenAsync
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
-        /// <param name="oauthBasePath"> Docusign OAuth base path
+        /// <param name="oAuthBasePathParam"> Docusign OAuth base path
         /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
@@ -1169,7 +1169,7 @@ namespace DocuSign.Maestro.Client
         /// <see cref="OAuth.Scope_SIGNATURE"/> <see cref="OAuth.Scope_IMPERSONATION"/> <see cref="OAuth.Scope_EXTENDED"/>
         /// </param>
         /// <returns>The JWT application token</returns>
-        public async Task<OAuth.OAuthToken> RequestJWTApplicationTokenAsync(string clientId, string oauthBasePath, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null, CancellationToken cancellationToken = default)
+        public async Task<OAuth.OAuthToken> RequestJWTApplicationTokenAsync(string clientId, string oAuthBasePathParam, byte[] privateKeyBytes, int expiresInHours, List<string> scopes = null, CancellationToken cancellationToken = default)
         {
             string privateKey = Encoding.UTF8.GetString(privateKeyBytes);
 
@@ -1184,7 +1184,7 @@ namespace DocuSign.Maestro.Client
 
             descriptor.Subject = new ClaimsIdentity();
             descriptor.Subject.AddClaim(new Claim("scope", String.Join(" ", scopes)));
-            descriptor.Subject.AddClaim(new Claim("aud", oauthBasePath));
+            descriptor.Subject.AddClaim(new Claim("aud", oAuthBasePathParam));
             descriptor.Subject.AddClaim(new Claim("iss", clientId));
 
             if (!string.IsNullOrEmpty(privateKey))
@@ -1206,7 +1206,7 @@ namespace DocuSign.Maestro.Client
                 { "assertion", jwtToken }
             };
 
-            DocuSignRequest request = PrepareOAuthRequest(oauthBasePath, $"oauth/token", HttpMethod.Post, Configuration.DefaultHeader?.ToList(), localVarFormParams.ToList());
+            DocuSignRequest request = PrepareOAuthRequest(oAuthBasePathParam, $"oauth/token", HttpMethod.Post, Configuration.DefaultHeader?.ToList(), localVarFormParams.ToList());
             DocuSignResponse response = await RestClient.SendRequestAsync(request, cancellationToken);
 
             if (response.StatusCode >= HttpStatusCode.OK && response.StatusCode < HttpStatusCode.BadRequest)

--- a/sdk/src/DocuSign.Maestro/DocuSign.Maestro.csproj
+++ b/sdk/src/DocuSign.Maestro/DocuSign.Maestro.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>DocuSign.Maestro</RootNamespace>
     <AssemblyName>DocuSign.Maestro</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <VersionSuffix/>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -26,7 +26,7 @@
     <PackageLicenseUrl>https://github.com/docusign/docusign-maestro-csharp-client/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/docusign/docusign-maestro-csharp-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>[v1.0.1] - Maestro API v1.0.0-1.0.5 - 11/7/2024</PackageReleaseNotes>
+    <PackageReleaseNotes>[v1.0.2] - Maestro API v1.0.0-1.0.5 - 11/15/2024</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462'">
     <DefineConstants>NET462</DefineConstants>
@@ -38,10 +38,10 @@
     <Reference Include="System.Web"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.2"/>
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.2.0"/>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1"/>
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0"/>
   </ItemGroup>
   <ItemGroup/>
 </Project>

--- a/sdk/src/DocuSign.Maestro/Properties/AssemblyInfo.cs
+++ b/sdk/src/DocuSign.Maestro/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 internal class AssemblyInformation
 {
-    public const string AssemblyInformationalVersion = "1.0.1";
+    public const string AssemblyInformationalVersion = "1.0.2";
 }


### PR DESCRIPTION
### Changed
- Resolved an issue that prevented the use of `RequestJWTApplicationToken` with a production account URL.
- Updated C# SDK dependencies.
    - BouncyCastle.Cryptography: Version bumped from 2.3.1 to 2.4.0.
    - Microsoft.IdentityModelJsonWebTokens: Version bumped from 7.5.2 to 8.2.0.
- Updated the SDK release version.
